### PR TITLE
Set width of icon

### DIFF
--- a/_src/css/psdle.css
+++ b/_src/css/psdle.css
@@ -286,8 +286,8 @@ span[id^=system_],
     max-width: 100%;
     vertical-align: middle;
     padding: 3px;
-    min-width: 42px;
-    min-height: 42px
+    width: 42px;
+    height: 42px
 }
 /*Sorting        */
 


### PR DESCRIPTION
Set width of icon, so items do not resize when the icons load in instead of using min-width